### PR TITLE
Explode AAR libraries to unique folders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compile gradleApi()
 }
 
-version="1.0"
+version="1.0.2"
 
 pluginBundle {
   website='https://github.com/greensopinion/gradle-android-eclipse'
@@ -39,3 +39,5 @@ buildscript {
     }
   }
 }
+
+archivesBaseName = 'android-eclipse'

--- a/src/main/java/com/greensopinion/gradle/android/eclipse/AddSourceFoldersAction.java
+++ b/src/main/java/com/greensopinion/gradle/android/eclipse/AddSourceFoldersAction.java
@@ -20,11 +20,23 @@ import org.gradle.plugins.ide.eclipse.model.Classpath;
 import org.gradle.plugins.ide.eclipse.model.SourceFolder;
 
 public class AddSourceFoldersAction implements Action<Classpath> {
-
+	
+	private AndroidEclipseExtension ext;
+	
+	public AddSourceFoldersAction(AndroidEclipseExtension ext) {
+		this.ext = ext;
+	}
+	
 	@Override
 	public void execute(Classpath classpath) {
 		Log.log().info("Adding Android source folders");
-		classpath.getEntries().add(new SourceFolder("src/main/java", "bin"));
+		
+		String srcDir = EclipseGeneratorPlugin.DEFAULT_SRC_DIR;
+		if (ext != null && ext.srcDir != null) {
+			srcDir = ext.srcDir;
+		}
+		
+		classpath.getEntries().add(new SourceFolder(srcDir, "bin"));
 		classpath.getEntries().add(new SourceFolder("build/generated/source/r/debug", "bin"));
 		classpath.getEntries().add(new SourceFolder("build/generated/source/buildConfig/debug", "bin"));
 		classpath.getEntries().add(new SourceFolder("build/generated/source/aidl/debug", "bin"));

--- a/src/main/java/com/greensopinion/gradle/android/eclipse/AndroidEclipseExtension.java
+++ b/src/main/java/com/greensopinion/gradle/android/eclipse/AndroidEclipseExtension.java
@@ -1,0 +1,17 @@
+package com.greensopinion.gradle.android.eclipse;
+
+
+public class AndroidEclipseExtension {
+	
+	String srcDir;
+	String aarOutputDir;
+	
+	public void setSrcDir(String srcDir) {
+		this.srcDir = srcDir;
+	}
+
+	public void setAarOutputDir(String aarOutputDir) {
+		this.aarOutputDir = aarOutputDir;
+	}
+
+}

--- a/src/main/java/com/greensopinion/gradle/android/eclipse/AndroidEclipseTask.java
+++ b/src/main/java/com/greensopinion/gradle/android/eclipse/AndroidEclipseTask.java
@@ -1,0 +1,42 @@
+package com.greensopinion.gradle.android.eclipse;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
+import org.slf4j.Logger;
+
+import groovy.lang.MissingPropertyException;
+
+public class AndroidEclipseTask extends DefaultTask {
+
+	@TaskAction
+	public void run() {
+		Logger logger = Log.log();
+
+		Project project = getProject();
+		AndroidEclipseExtension ext = (AndroidEclipseExtension) project.getExtensions().getByName(EclipseGeneratorPlugin.PLUGIN_NAME);
+		
+		logger.info("Updating eclipse model with Android dependencies");
+		
+		EclipseModel eclipseModel = (EclipseModel) eclipseModel(project);
+		eclipseModel.getClasspath().getFile().beforeMerged(new AddSourceFoldersAction(ext));
+		eclipseModel.getClasspath().getFile().whenMerged(new GenerateLibraryDependenciesAction(project, ext));
+		eclipseModel.getClasspath().getFile().whenMerged(new AndroidSdkLibraryDependenciesAction(project));
+		
+		project.getTasksByName("eclipseClasspath", false).forEach(t -> t.dependsOn("generateDebugSources"));
+		
+		logger.info("Android dependencies done");
+	}
+	
+	private EclipseModel eclipseModel(Project project) {
+		try {
+			return (EclipseModel) project.property("eclipse");
+		} catch (MissingPropertyException e) {
+			throw new RuntimeException(
+					"Cannot find 'eclipse' property.\nEnsure that the following is in your project: \n\napply plugin: 'eclipse'\n\n",
+					e);
+		}
+	}
+	
+}

--- a/src/main/java/com/greensopinion/gradle/android/eclipse/EclipseGeneratorPlugin.java
+++ b/src/main/java/com/greensopinion/gradle/android/eclipse/EclipseGeneratorPlugin.java
@@ -15,44 +15,22 @@
  */
 package com.greensopinion.gradle.android.eclipse;
 
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.plugins.ide.eclipse.model.EclipseModel;
-import org.slf4j.Logger;
 
-import groovy.lang.MissingPropertyException;
 
 public class EclipseGeneratorPlugin implements Plugin<Project> {
+	
+	public static final String PLUGIN_NAME = "androidEclipse";
+	public static final String MAIN_TASK_NAME = "androidEclipse";
+	
+	public static final String DEFAULT_SRC_DIR = "src/main/java";
+	public static final String DEFAULT_AAR_EXPLODED_DIR = "build/exploded-aars";
+	
 	@Override
 	public void apply(Project project) {
-		Logger logger = Log.log();
-		project.afterEvaluate(new Action<Project>() {
-
-			@Override
-			public void execute(Project project) {
-				logger.info("Updating eclipse model with Android dependencies");
-
-				EclipseModel eclipseModel = eclipseModel(project);
-				eclipseModel.getClasspath().getFile().beforeMerged(new AddSourceFoldersAction());
-				eclipseModel.getClasspath().getFile().whenMerged(new GenerateLibraryDependenciesAction(project));
-				eclipseModel.getClasspath().getFile().whenMerged(new AndroidSdkLibraryDependenciesAction(project));
-
-				project.getTasksByName("eclipseClasspath", false).forEach(t -> t.dependsOn("generateDebugSources"));
-
-				logger.info("Android dependencies done");
-			}
-		});
-
+		project.getExtensions().create(PLUGIN_NAME, AndroidEclipseExtension.class);
+		project.getTasks().create(MAIN_TASK_NAME, AndroidEclipseTask.class);
 	}
 
-	private EclipseModel eclipseModel(Project project) {
-		try {
-			return (EclipseModel) project.property("eclipse");
-		} catch (MissingPropertyException e) {
-			throw new RuntimeException(
-					"Cannot find 'eclipse' property.\nEnsure that the following is in your project: \n\napply plugin: 'eclipse'\n\n",
-					e);
-		}
-	}
 }

--- a/src/main/java/com/greensopinion/gradle/android/eclipse/GenerateLibraryDependenciesAction.java
+++ b/src/main/java/com/greensopinion/gradle/android/eclipse/GenerateLibraryDependenciesAction.java
@@ -38,9 +38,11 @@ import org.gradle.plugins.ide.eclipse.model.internal.FileReferenceFactory;
 public class GenerateLibraryDependenciesAction implements Action<Classpath> {
 
 	private final Project project;
+	private AndroidEclipseExtension ext;
 
-	public GenerateLibraryDependenciesAction(Project project) {
+	public GenerateLibraryDependenciesAction(Project project, AndroidEclipseExtension ext) {
 		this.project = project;
+		this.ext = ext;
 	}
 
 	@Override
@@ -65,8 +67,14 @@ public class GenerateLibraryDependenciesAction implements Action<Classpath> {
 
 	private Stream<ClasspathEntry> explodeAarJarFiles(Library aarLibrary) {
 		File aarFile = new File(aarLibrary.getPath());
-    String jarId = aarLibrary.getModuleVersion().toString().replaceAll(":", "-");
-    File targetFolder = new File(new File(new File(project.getProjectDir(), "build"), "exploded-aars"), jarId);
+		String jarId = aarLibrary.getModuleVersion().toString().replaceAll(":", "-");
+		
+		String aarDir = EclipseGeneratorPlugin.DEFAULT_AAR_EXPLODED_DIR;
+		if (ext != null && ext.aarOutputDir != null) {
+			aarDir = ext.aarOutputDir;
+		}
+		File targetFolder = new File(new File(project.getProjectDir(), aarDir), jarId);
+		
 		if (!targetFolder.exists()) {
 			if (!targetFolder.mkdirs()) {
 				throw new RuntimeException(format("Cannot create folder: {0}", targetFolder.getAbsolutePath()));
@@ -74,7 +82,7 @@ public class GenerateLibraryDependenciesAction implements Action<Classpath> {
 			try (ZipFile zipFile = new ZipFile(aarFile)) {
 				zipFile.stream().forEach(f -> {
 					if (f.getName().endsWith(".jar")) {
-            String targetName = jarId + ".jar";
+						String targetName = jarId + ".jar";
 						File targetFile = new File(targetFolder, targetName);
 						ensureParentFolderExists(targetFile);
 						int index = 1;
@@ -89,10 +97,18 @@ public class GenerateLibraryDependenciesAction implements Action<Classpath> {
 						format("Cannot explode aar: {0}: {1}", e.getMessage(), aarFile.getAbsolutePath()), e);
 			}
 		}
+
 		List<File> files = listFilesTraversingFolders(targetFolder);
 		FileReferenceFactory fileReferenceFactory = new FileReferenceFactory();
+
 		return files.stream().filter(f -> f.getName().endsWith(".jar")).map(f -> {
 			Library library = new Library(fileReferenceFactory.fromFile(f));
+			
+			String rootPath = project.getProjectDir().getAbsolutePath().replaceAll("\\\\", "/");
+			String localPath = library.getPath().replace(rootPath, "");
+			if (localPath.charAt(0) == '/') localPath = localPath.substring(1);
+			library.setPath(localPath);
+			
 			library.setSourcePath(aarLibrary.getSourcePath());
 			return library;
 		});

--- a/src/main/java/com/greensopinion/gradle/android/eclipse/GenerateLibraryDependenciesAction.java
+++ b/src/main/java/com/greensopinion/gradle/android/eclipse/GenerateLibraryDependenciesAction.java
@@ -65,22 +65,23 @@ public class GenerateLibraryDependenciesAction implements Action<Classpath> {
 
 	private Stream<ClasspathEntry> explodeAarJarFiles(Library aarLibrary) {
 		File aarFile = new File(aarLibrary.getPath());
-		File targetFolder = new File(new File(new File(project.getProjectDir(), "build"), "exploded-aars"),
-				aarFile.getName());
+    String jarId = aarLibrary.getModuleVersion().toString().replaceAll(":", "-");
+    File targetFolder = new File(new File(new File(project.getProjectDir(), "build"), "exploded-aars"), jarId);
 		if (!targetFolder.exists()) {
 			if (!targetFolder.mkdirs()) {
 				throw new RuntimeException(format("Cannot create folder: {0}", targetFolder.getAbsolutePath()));
 			}
 			try (ZipFile zipFile = new ZipFile(aarFile)) {
-				zipFile.stream().forEach(e -> {
-					if (e.getName().endsWith(".jar")) {
-						File targetFile = new File(targetFolder, e.getName());
+				zipFile.stream().forEach(f -> {
+					if (f.getName().endsWith(".jar")) {
+            String targetName = jarId + ".jar";
+						File targetFile = new File(targetFolder, targetName);
 						ensureParentFolderExists(targetFile);
 						int index = 1;
 						while (targetFile.exists()) {
-							targetFile = new File(targetFolder, format("{0}_{1}", ++index, e.getName()));
+							targetFile = new File(targetFolder, format("{0}_{1}", ++index, targetName));
 						}
-						copy(zipFile, targetFile, e);
+						copy(zipFile, targetFile, f);
 					}
 				});
 			} catch (IOException e) {


### PR DESCRIPTION
Changes:  
- aar libraries explode to unique folders generated from `group:id:version` sets, and to unique .jar files
- renamed forEach variable to `'f'` to distinguish it from `'Exception e'`

Before AAR `classes.jar` files were extracted to folders with the names of AAR artifact files.  
This provoked conflicts when there are 2 dependencies with different groups and the same AAR names.

As for:

    android.arch.core:runtime:1.1.0
    android.arch.lifecycle:runtime:1.1.0

Also I propose to use `archivesBaseName = 'android-eclipse'` property in the `build.gradle` as it generates artifacts with name **"android-eclipse"** instead of the default **"gradle-android-eclipse"**. Just more comfortable for development.

Thanks.