### PR TITLE
Explode AAR libraries to unique folders [Corrected]

### DIFF
--- a/src/main/java/com/greensopinion/gradle/android/eclipse/GenerateLibraryDependenciesAction.java
+++ b/src/main/java/com/greensopinion/gradle/android/eclipse/GenerateLibraryDependenciesAction.java
@@ -65,8 +65,8 @@ public class GenerateLibraryDependenciesAction implements Action<Classpath> {
 
 	private Stream<ClasspathEntry> explodeAarJarFiles(Library aarLibrary) {
 		File aarFile = new File(aarLibrary.getPath());
-    String jarId = aarLibrary.getModuleVersion().toString().replaceAll(":", "-");
-    File targetFolder = new File(new File(new File(project.getProjectDir(), "build"), "exploded-aars"), jarId);
+		String jarId = aarLibrary.getModuleVersion().toString().replaceAll(":", "-");
+		File targetFolder = new File(new File(new File(project.getProjectDir(), "build"), "exploded-aars"), jarId);
 		if (!targetFolder.exists()) {
 			if (!targetFolder.mkdirs()) {
 				throw new RuntimeException(format("Cannot create folder: {0}", targetFolder.getAbsolutePath()));
@@ -74,7 +74,7 @@ public class GenerateLibraryDependenciesAction implements Action<Classpath> {
 			try (ZipFile zipFile = new ZipFile(aarFile)) {
 				zipFile.stream().forEach(f -> {
 					if (f.getName().endsWith(".jar")) {
-            String targetName = jarId + ".jar";
+						String targetName = jarId + ".jar";
 						File targetFile = new File(targetFolder, targetName);
 						ensureParentFolderExists(targetFile);
 						int index = 1;

--- a/src/main/java/com/greensopinion/gradle/android/eclipse/GenerateLibraryDependenciesAction.java
+++ b/src/main/java/com/greensopinion/gradle/android/eclipse/GenerateLibraryDependenciesAction.java
@@ -65,22 +65,23 @@ public class GenerateLibraryDependenciesAction implements Action<Classpath> {
 
 	private Stream<ClasspathEntry> explodeAarJarFiles(Library aarLibrary) {
 		File aarFile = new File(aarLibrary.getPath());
-		File targetFolder = new File(new File(new File(project.getProjectDir(), "build"), "exploded-aars"),
-				aarFile.getName());
+    String jarId = aarLibrary.getModuleVersion().toString().replaceAll(":", "-");
+    File targetFolder = new File(new File(new File(project.getProjectDir(), "build"), "exploded-aars"), jarId);
 		if (!targetFolder.exists()) {
 			if (!targetFolder.mkdirs()) {
 				throw new RuntimeException(format("Cannot create folder: {0}", targetFolder.getAbsolutePath()));
 			}
 			try (ZipFile zipFile = new ZipFile(aarFile)) {
-				zipFile.stream().forEach(e -> {
-					if (e.getName().endsWith(".jar")) {
-						File targetFile = new File(targetFolder, e.getName());
+				zipFile.stream().forEach(f -> {
+					if (f.getName().endsWith(".jar")) {
+            String targetName = jarId + ".jar";
+						File targetFile = new File(targetFolder, targetName);
 						ensureParentFolderExists(targetFile);
 						int index = 1;
 						while (targetFile.exists()) {
-							targetFile = new File(targetFolder, format("{0}_{1}", ++index, e.getName()));
+							targetFile = new File(targetFolder, format("{0}_{1}", ++index, targetName));
 						}
-						copy(zipFile, targetFile, e);
+						copy(zipFile, targetFile, f);
 					}
 				});
 			} catch (IOException e) {


### PR DESCRIPTION
Changes:  
- aar libraries explode to unique folders generated from `group:id:version` sets, and to unique .jar files
- renamed forEach variable to `'f'` to distinguish it from `'Exception e'`

Before AAR `classes.jar` files were extracted to folders with the names of AAR artifact files.  
This provoked conflicts when there are 2 dependencies with different groups and the same AAR names.

As for:

    android.arch.core:runtime:1.1.0
    android.arch.lifecycle:runtime:1.1.0

Also I propose to use `archivesBaseName = 'android-eclipse'` property in the `build.gradle` as it generates artifacts with name **"android-eclipse"** instead of the default **"gradle-android-eclipse"**. Just more comfortable for development.

Thanks.
