### PR TITLE
Fix M2 url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the following to your build.gradle:
 	        }
 	    }
 	    dependencies {
-	      classpath "gradle.plugin.com.greensopinion.gradle-android-eclipse:android-eclipse:1.1"
+	      classpath "gradle.plugin.com.greensopinion.gradle-android-eclipse:gradle-android-eclipse:1.1"
 	    }
 	}
 


### PR DESCRIPTION
The Maven plugin name was wrong in the README, apparently you changed it from `android-eclipse` to `gradle-android-eclipse`.