### PR TITLE
build.gradle: Maintain compatibility to JDK 8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 }
 
 version="1.1"
+sourceCompatibility = 1.8
 
 pluginBundle {
   website='https://github.com/greensopinion/gradle-android-eclipse'


### PR DESCRIPTION
There is no reason to rush to higher JDK versions. A lot of developers can't upgrade past JDK 8 because of the breaking changes that were introduced with 9 and 10.